### PR TITLE
Update polkadot-chains.ts

### DIFF
--- a/src/configs/chains/polkadot-chains.ts
+++ b/src/configs/chains/polkadot-chains.ts
@@ -7,9 +7,9 @@ export const polkadotChains = {
     ss58Prefix: 0,
   },
   statemint: {
-    display: "Statemint",
+    display: "Polkadot Asset Hub",
     type: "substrate",
-    icon: "https://resources.acala.network/_next/image?url=%2Fnetworks%2Fstatemine.png&w=96&q=75",
+    icon: "https://raw.githubusercontent.com/novasamatech/nova-utils/afda42bc3542723e57014eaba278613bd8aad3e9/icons/chains/gradient/Polkadot_Asset_Hub.svg",
     paraChainId: 1000,
     ss58Prefix: 0,
   },


### PR DESCRIPTION
Changed display name of "Statemint" to "Polkadot Asset Hub". 
Updated icon to Polkadot Asset Hub chain icon svg.

Hopefully this helps towards this issue: https://github.com/galacticcouncil/apps/issues/62

Please sers the normies don't know what Statemint is anymore 😩